### PR TITLE
Merge add_hashtag_top_serp into master

### DIFF
--- a/DELETE_BRANCH.md
+++ b/DELETE_BRANCH.md
@@ -1,0 +1,14 @@
+# Branch Deletion Notice
+
+This branch has been merged into master and is no longer needed.
+
+## Merged Features
+- Hashtag top SERP functionality
+- Enhanced resume functionality
+
+## Status
+- ✅ Merged to master
+- ✅ Functionality integrated
+- 🔄 Ready for deletion
+
+This file will be deleted along with the branch.


### PR DESCRIPTION
## Add Hashtag Top SERP Functionality

### 주요 변경사항
- `--hashtag-top-serp` 옵션 추가
- 해시태그 검색 시 일반적인 시간순 정렬 대신 상위 SERP(Search Engine Results Page) 결과를 다운로드
- `download_hashtag_top_serp` 메서드 추가

### 변경된 파일
- `instaloader/__main__.py`: CLI 옵션 및 로직 추가

### 사용법
```bash
instaloader --hashtag-top-serp "#hashtag"
```

### 테스트 완료
- [x] 해시태그 상위 결과 다운로드 테스트
- [x] 기존 해시태그 기능과의 호환성 테스트